### PR TITLE
add support for libjemalloc.so.2

### DIFF
--- a/lua/memory.lua
+++ b/lua/memory.lua
@@ -19,6 +19,10 @@ local function loadAllocator()
 	if ok then
 		return jemalloc, "jemalloc"
 	end
+	local ok, jemalloc = pcall(ffi.load, "libjemalloc.so.2")
+	if ok then
+		return jemalloc, "jemalloc"
+	end
 	return ffi.C, "system malloc"
 end
 


### PR DESCRIPTION
Some distributions (like Fedora 25) uses jemalloc 4.4.0 that have ABI dump to libjemalloc.so.2