### PR TITLE
Add best-effort single packet send

### DIFF
--- a/lua/device.lua
+++ b/lua/device.lua
@@ -738,6 +738,13 @@ function txQueue:sendSingle(buf)
 	return 1
 end
 
+-- Try to transmit a single packet.
+-- Returns be 1 if sent, 0 if not
+function txQueue:trySendSingle(buf)
+	self.used = true
+	return dpdkc.dpdk_try_send_single_packet(self.id, self.qid, buf)
+end
+
 function txQueue:sendN(bufs, n)
 	self.used = true
 	dpdkc.dpdk_send_all_packets(self.id, self.qid, bufs.array, n)

--- a/lua/device.lua
+++ b/lua/device.lua
@@ -739,7 +739,7 @@ function txQueue:sendSingle(buf)
 end
 
 -- Try to transmit a single packet.
--- Returns be 1 if sent, 0 if not
+-- Returns 1 if sent, 0 if not
 function txQueue:trySendSingle(buf)
 	self.used = true
 	return dpdkc.dpdk_try_send_single_packet(self.id, self.qid, buf)

--- a/lua/dpdkc.lua
+++ b/lua/dpdkc.lua
@@ -287,6 +287,7 @@ ffi.cdef[[
 	int rte_eth_dev_tx_queue_stop(uint8_t port_id, uint16_t rx_queue_id);
 	void dpdk_send_all_packets(uint8_t port_id, uint16_t queue_id, struct rte_mbuf** pkts, uint16_t num_pkts);
 	void dpdk_send_single_packet(uint8_t port_id, uint16_t queue_id, struct rte_mbuf* pkt);
+	uint16_t dpdk_try_send_single_packet(uint8_t port_id, uint16_t queue_id, struct rte_mbuf* pkt);
 
 	// stats
 	uint32_t dpdk_get_rte_queue_stat_cntrs_num();

--- a/src/device.c
+++ b/src/device.c
@@ -297,6 +297,13 @@ void dpdk_send_single_packet(uint8_t port_id, uint16_t queue_id, struct rte_mbuf
 	return;
 }
 
+
+uint16_t dpdk_try_send_single_packet(uint8_t port_id, uint16_t queue_id, struct rte_mbuf* pkt) {
+	uint16_t sent = 0;
+	sent = rte_eth_tx_burst(port_id, queue_id, &pkt, 1);
+	return sent;
+}
+
 // receive packets and save the tsc at the time of the rx call
 // this prevents potential gc/jit pauses right between the rdtsc and rx calls
 uint16_t dpdk_receive_with_timestamps_software(uint8_t port_id, uint16_t queue_id, struct rte_mbuf* rx_pkts[], uint16_t nb_pkts) {


### PR DESCRIPTION
Add function to attempt to send single packet.

Does not block until sent like other sendSingle function.
Does not guarantee successful transmission.