### PR TITLE
Change the link lua/lib/jit from -beta2 to -beta3

### DIFF
--- a/lua/lib/jit
+++ b/lua/lib/jit
@@ -1,1 +1,1 @@
-../../deps/luajit/usr/local/share/luajit-2.1.0-beta2/jit
+../../deps/luajit/usr/local/share/luajit-2.1.0-beta3/jit


### PR DESCRIPTION
This fix resolves problems ocurring after the first clone
(i.e the beta2 version does not exist) by changing the link
from deps/luajit/usr/local/share/luajit-2.1.0-beta2/jit to
     deps/luajit/usr/local/share/luajit-2.1.0-beta3/jit
due to the update of the luajit compiler