### PR TITLE
Add ENA driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ SET(DPDK_LIBS
 	rte_acl      rte_eal          rte_kvargs   	 rte_mempool   rte_mempool_ring	  rte_pmd_e1000        rte_pmd_virtio   rte_ring
 	rte_cfgfile  rte_hash         rte_lpm      	 rte_meter     rte_pmd_i40e   	  rte_pmd_vmxnet3_uio  rte_sched        rte_timer
 	rte_cmdline  rte_ip_frag      rte_pipeline 	 rte_pmd_ixgbe rte_mempool_stack  rte_port             rte_table        rte_pmd_bnxt
+	rte_pmd_ena
 )
 
 #Add Mellanox libraries if options are specified

--- a/lua/driver/ena.lua
+++ b/lua/driver/ena.lua
@@ -1,0 +1,3 @@
+local dev = {}
+
+return dev

--- a/lua/drivers.lua
+++ b/lua/drivers.lua
@@ -11,6 +11,7 @@ mod.net_e1000_em = require "driver.igb"
 mod.net_virtio = require "driver.virtio"
 mod.net_vmxnet3 = require "driver.vmxnet3"
 mod.net_mlx5 = require "driver.mlx5"
+mod.net_ena = require "driver.ena"
 
 function mod.initDriver(dev)
 	local device = require "device"


### PR DESCRIPTION
ENA is a network driver supported on newer EC2 instance types and has full DPDK support. It does not have hardware timestamping support but software timestamping works as expected.