### PR TITLE
Fix typos in libmoon/lua/pcap.lua

### DIFF
--- a/lua/pcap.lua
+++ b/lua/pcap.lua
@@ -188,7 +188,7 @@ ffi.cdef[[
 --- Read the next packet into a buf, the timestamp is stored in the udata64 field as microseconds.
 --- The buffer's packet size corresponds to the original packet size, cut off bytes are zero-filled.
 function reader:readSingle(mempool, mempoolBufSize)
-	mempoolBufSize = memPoolBufSize or 2048
+	mempoolBufSize = mempoolBufSize or 2048
 	local fileRemaining = self.size - self.offset
 	if fileRemaining < 32 then -- header size
 		return nil
@@ -206,7 +206,7 @@ end
 --- The buffer's packet size corresponds to the original packet size, cut off bytes are zero-filled.
 --- @return the number of packets read
 function reader:read(bufs, mempoolBufSize)
-	mempoolBufSize = memPoolBufSize or 2048
+	mempoolBufSize = mempoolBufSize or 2048
 	local fileRemaining = self.size - self.offset
 	if fileRemaining < 32 then -- header size
 		return 0


### PR DESCRIPTION
`mempoolBufSize` was misspelled twice as `memPoolBufSize` which lead to `mempoolBufSize` always being `2048`.