### PR TITLE
Update mempool create function in order to be able to pass mempool, socket and bufSize arguments

### DIFF
--- a/lua/memory.lua
+++ b/lua/memory.lua
@@ -171,7 +171,9 @@ end
 --- @param	bufSize optional the size of each buffer, can only be used if all other args are passed as well
 function mod.createMemPool(...)
 	local args = {...}
-	if type(args[1]) == "table" then
+	if args[2] and type(args[2]) == "table" then
+		args = args[2]
+	elseif type(args[1]) == "table" then
 		args = args[1]
 	else
 		if type(args[1]) == "function" then


### PR DESCRIPTION
Update `mod.createMemPool(...)` function arguments handling in order to be able to pass arguments when creating mempool from scripts using:
`local mempool = memory:createMemPool{bufSize = bufsize}`
It's needed, because when you are passing arguments to createMemPool from scripts, they are stored in as a second table object, but args[1] are used as arguments:
```
[INFO]  Device 0 (90:E2:BA:B4:76:D0) is up: 10000 MBit/s
[INFO]  1 device is up.
[INFO]  Args[1] - table:
alloc	function: 0x4085ea08
enableCache	function: 0x4085ec70
createMemPool	function: 0x4085f5c0
testAllocationSpace	function: 0x4085e9c0
freeHuge	function: 0x4085eaf8
allocHuge	function: 0x4030f3e0
createBufArray	function: 0x4085f680
bufArray	function: 0x4085f680
free	function: 0x4085ea50
freeMemPools	function: 0x4085f630
[INFO]  Args[2] - table:
bufSize	15872
[INFO]  mempool size: 2047, buf size: 15872
```