### PR TITLE
Implement missing rte_ring functions

### DIFF
--- a/src/ring.c
+++ b/src/ring.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <rte_config.h>
 #include <rte_common.h>
 #include <rte_ring.h>
@@ -12,6 +13,10 @@ struct rte_ring* create_ring(uint32_t count, int32_t socket) {
 	return rte_ring_create(ring_name, count, socket, RING_F_SP_ENQ | RING_F_SC_DEQ);
 }
 
+void free_ring(struct rte_ring* r) {
+	rte_ring_free(r);
+}
+
 int ring_enqueue(struct rte_ring* r, void* const* obj, int n) {
 	return rte_ring_sp_enqueue_bulk(r, obj, n, NULL);
 }
@@ -20,3 +25,18 @@ int ring_dequeue(struct rte_ring* r, void** obj, int n) {
 	return rte_ring_sc_dequeue_bulk(r, obj, n, NULL);
 }
 
+int ring_count(struct rte_ring* r) {
+	return rte_ring_count(r);
+}
+
+int ring_free_count(struct rte_ring* r) {
+	return rte_ring_free_count(r);
+}
+
+bool ring_empty(struct rte_ring* r) {
+	return rte_ring_empty(r) == 1;
+}
+
+bool ring_full(struct rte_ring* r) {
+	return rte_ring_full(r) == 1;
+}


### PR DESCRIPTION
This PR exposes some functions from `rte_ring.h` and also implements `packetRing:recv()`.