### PR TITLE
modify to show IP MF(more fragment flag)

### DIFF
--- a/lua/proto/ip4.lua
+++ b/lua/proto/ip4.lua
@@ -276,7 +276,7 @@ end
 --- Retrieve the flags. 
 --- @return Flags as 3 bit integer.
 function ip4Header:getFlags()
-	return band(rshift(hton16(self.frag), 13), 0x000e)
+	return band(rshift(hton16(self.frag), 13), 0x0007)
 end
 
 --- Retrieve the flags. 


### PR DESCRIPTION
After rshift,the MF flag bit is in the last bit. 0x000e is 0000 0000 0000 1110,after bit and operation, it will drop this bit, so it should modifty to 0x0007 (0000 0000 0000 0111). Thanks.