### PR TITLE
fix original length in pcap files

### DIFF
--- a/src/pcap.cpp
+++ b/src/pcap.cpp
@@ -20,7 +20,7 @@ extern "C" {
 		dst->ts_sec = ts_sec;
 		dst->ts_usec = ts_usec;
 		dst->incl_len = len;
-		dst->orig_len = len;
+		dst->orig_len = orig_len;
 		memcpy(&dst->data, packet, len);
 	}
 


### PR DESCRIPTION
pcaps would always store the truncated length as the original length