### PR TITLE
[install-mlx.md] additional notes for mlx5 usage

### DIFF
--- a/install-mlx.md
+++ b/install-mlx.md
@@ -8,7 +8,7 @@ In order to use MoonGen/libmoon with Mellanox NICs some addtional steps are nece
 Additional prerequisites
 ------------------------
 
- - Mellanox OFED version: ``4.1``; Download from [here](http://www.mellanox.com/page/products_dyn?product_family=26&mtag=linux). Other versions may work (check the [driver compatibility matrix](http://www.mellanox.com/page/mlnx_ofed_matrix?mtag=linux_sw_drivers)), though that has not been tested.
+ - Mellanox OFED version: ``4.1``; Download from [here](http://www.mellanox.com/page/products_dyn?product_family=26&mtag=linux). Other versions may work (check the [driver compatibility matrix](http://www.mellanox.com/page/mlnx_ofed_matrix?mtag=linux_sw_drivers)), though that has not been tested. On the other hand, the complete ``OFED 4.1`` might no more be installable on current distributions.
 	
 	Use one of the following options for installation:
 
@@ -52,7 +52,7 @@ If all prerequisites are fulfilled, install MoonGen/libmoon by executing:
 
 	build.sh --mlx5 --mlx4
 
-Leave out Flags which are not needed. Currently only mlx5 is tested and has custom driver patches. However, user reported success with mlx4 devices.
+Leave out Flags which are not needed. Currently only mlx5 is tested and has custom driver patches. However, user reported success with mlx4 devices. For mlx5, the warnings from ``bind-interfaces.sh`` can be ignored, since it is using a bifurcated driver (see DPDK docs about the MLX5 PMD). Just leave out ``bind-interfaces.sh`` and continue with ``setup-hugetlbfs.sh`` instead.
 
 
 Troubleshooting

--- a/install-mlx.md
+++ b/install-mlx.md
@@ -8,7 +8,7 @@ In order to use MoonGen/libmoon with Mellanox NICs some addtional steps are nece
 Additional prerequisites
 ------------------------
 
- - Mellanox OFED version: ``4.1``; Download from [here](http://www.mellanox.com/page/products_dyn?product_family=26&mtag=linux). Other versions may work (check the [driver compatibility matrix](http://www.mellanox.com/page/mlnx_ofed_matrix?mtag=linux_sw_drivers)), though that has not been tested. On the other hand, the complete ``OFED 4.1`` might no more be installable on current distributions.
+ - Mellanox OFED version: ``4.1``; Download from [here](http://www.mellanox.com/page/products_dyn?product_family=26&mtag=linux). Other versions may work (check the [driver compatibility matrix](http://www.mellanox.com/page/mlnx_ofed_matrix?mtag=linux_sw_drivers)), though currently only ``OFED 4.1`` and ``OFED 4.4`` have been tested.
 	
 	Use one of the following options for installation:
 


### PR DESCRIPTION
Hi,

I was unable to install OFED 4.1 itself on any Ubuntu version downto 14.04, but it seems to work with OFED 4.4 (which I tried as last option because what was written in ``install-mlx.md``). Also, I had some warnings from ``bind-interfaces.sh`` which seem to be because MLX5 is using a bifurcated driver, where DPDK controls the NIC *alongside* with the normal kernel mode driver, as it is described in the DPDK docs about MLX5 PMD.

````
kay@kay-ub16:~/libmoon$ sudo bash build.sh
[...]
[ 47%] Building C object CMakeFiles/libmoon.dir/src/timestamping_ixgbe.c.o
[ 52%] Building C object CMakeFiles/libmoon.dir/src/timestamping_igb.c.o
[ 56%] Building CXX object CMakeFiles/libmoon.dir/src/pktsizedring.cpp.o
[ 60%] Building CXX object CMakeFiles/libmoon.dir/src/bytesizedring.cpp.o
[ 65%] Building C object CMakeFiles/libmoon.dir/src/timestamping_i40e.c.o
[ 69%] Linking CXX executable libmoon
[100%] Built target libmoon
Trying to bind interfaces, this will fail if you are not root
Try sudo ./bind-interfaces.sh if this step fails
Binding applicable NICs to mlx5_core
Could not find any inactive interfaces to bind to DPDK. Note that this script does not bind interfaces that are in use by the OS.
Delete IP addresses from interfaces you would like to use with libmoon and run this script again.
You can also use the script dpdk-devbind.py in deps/dpdk/usertools manually to manage interfaces used by libmoon and the OS.
kay@kay-ub16:~/libmoon$ sudo ./setup-hugetlbfs.sh 
kay@kay-ub16:~/libmoon$ sudo ./build/libmoon examples/hello-world.lua 
[INFO]  Initializing DPDK. This will take a few seconds...
EAL: Detected 16 lcore(s)
EAL: No free hugepages reported in hugepages-1048576kB
EAL: Probing VFIO support...
EAL: WARNING: cpu flags constant_tsc=yes nonstop_tsc=no -> using unreliable clock cycles !
EAL: PCI device 0000:00:03.0 on NUMA socket -1
EAL:   Invalid NUMA socket, default to 0
EAL:   probe driver: 1af4:1000 net_virtio
EAL: PCI device 0000:00:07.0 on NUMA socket -1
EAL:   Invalid NUMA socket, default to 0
EAL:   probe driver: 15b3:1017 net_mlx5
PMD: net_mlx5: PCI information matches, using device "mlx5_0" (SR-IOV: false, Enhanced MPS: true)
PMD: net_mlx5: 1 port(s) detected
PMD: net_mlx5: Enhanced MPS is enabled
PMD: net_mlx5: port 1 MAC address is 50:6b:4b:d4:3e:60
EAL: PCI device 0000:00:08.0 on NUMA socket -1
EAL:   Invalid NUMA socket, default to 0
EAL:   probe driver: 15b3:1017 net_mlx5
PMD: net_mlx5: PCI information matches, using device "mlx5_1" (SR-IOV: false, Enhanced MPS: true)
PMD: net_mlx5: 1 port(s) detected
PMD: net_mlx5: Enhanced MPS is enabled
PMD: net_mlx5: port 1 MAC address is 50:6b:4b:d4:3e:61
[INFO]  Found 2 usable devices:
   Device 0: 50:6B:4B:D4:3E:60 (Mellanox Technologies MT27800 Family [ConnectX-5, PCIe 3.0])
   Device 1: 50:6B:4B:D4:3E:61 (Mellanox Technologies MT27800 Family [ConnectX-5, PCIe 3.0])
Hello, world!
Command line arguments: 
Slave task, received argument: "Hello, world from second slave!"
Slave task, received argument: "Hello, world from first slave!"
All slaves finished, exiting...
````

So I wrote a few words to hopefully make the setup easier.