### PR TITLE
Add tx vlan

### DIFF
--- a/lua/device.lua
+++ b/lua/device.lua
@@ -203,6 +203,7 @@ function mod.config(args)
 	if dev.init then
 		dev:init()
 	end
+	dev.txvlan = args.txvlan
 	dev:store()
 	dev:setPromisc(true)
 	if dev:getDriverName():match("i40e") then


### PR DESCRIPTION
Add as a configuration parameter per device a transmit vlan

The configured transmit vlan can be used by service protocols like ARP to transmit correctly encapsulated packets.

Add support in arp protocol for reading tx vlan configuration and using it in case ARPpacket is to be transmitted.