### PR TITLE
WIP: Add MPLS header support

### DIFF
--- a/lua/packet.lua
+++ b/lua/packet.lua
@@ -995,4 +995,6 @@ pkt.getGreQinQUdpPacket = function(self, ip4)
 	end
 end
 
+pkt.getMPLSPacket = createStack("eth", "mpls")
+
 return pkt

--- a/lua/proto/ethernet.lua
+++ b/lua/proto/ethernet.lua
@@ -42,6 +42,9 @@ eth.TYPE_8021Q = 0x8100
 --- EtherType for LACP (Actually, 'Slow Protocols')
 eth.TYPE_LACP = 0x8809
 
+--- EtherType for MPLS Unicast
+eth.TYPE_MPLS = 0x8847
+
 --- Special addresses
 --- Ethernet broadcast address
 eth.BROADCAST	= "ff:ff:ff:ff:ff:ff"
@@ -435,6 +438,7 @@ local mapNameType = {
 	arp = eth.TYPE_ARP,
 	ptp = eth.TYPE_PTP, 
 	lacp = eth.TYPE_LACP,
+	mpls = eth.TYPE_MPLS,
 }
 
 --- Resolve which header comes after this one (in a packet).

--- a/lua/proto/mpls.lua
+++ b/lua/proto/mpls.lua
@@ -1,0 +1,199 @@
+------------------------------------------------------------------------
+--- @file mpls.lua
+--- @brief (mpls) utility.
+--- Includes:
+--- - mpls constants
+--- - Definition of mpls packets
+------------------------------------------------------------------------
+
+local ffi = require "ffi"
+require "proto.template"
+local initHeader = initHeader
+
+local bor, band, bnot, rshift, lshift= bit.bor, bit.band, bit.bnot, bit.rshift, bit.lshift
+
+
+---------------------------------------------------------------------------
+---- mpls constants 
+---------------------------------------------------------------------------
+
+--- mpls protocol constants
+local mpls = {}
+
+
+---------------------------------------------------------------------------
+---- MPLS header
+---------------------------------------------------------------------------
+-- 1                   2                   3
+-- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
+-- |----------label----------------------|-exp-|-b-|----TTL--------|
+-- 0-20 Label
+-- 20-22 Experimental Bits (QoS) or Traffic Class (TC) field.
+-- 23 BoS (Bottom of Stack bit)
+-- 24-31 Time to Live (TTL)
+
+mpls.headerFormat = [[
+	uint8_t labelstart;
+	uint8_t labelmid;
+	uint8_t labelend_tc_s;
+	uint8_t ttl;
+]]
+
+--- Variable sized member
+mpls.headerVariableMember = nil
+
+--- Module for mpls_address struct
+local mplsHeader = initHeader()
+mplsHeader.__index = mplsHeader
+
+--- Set the Label
+--- @param int label of the mpls header as 20 bit integer.
+function mplsHeader:setLabel(int)
+	int = int or 4
+	-- Per block (8, 8, 4)
+	-- Only get the first 8
+	firstbits = rshift(band(int, 0xff000), 12)
+	self.labelstart = rshift(int, 24) -- retain the first 8 bits
+	-- The second set of 8
+	self.labelmid = rshift(band(int, 0xff0), 4) -- retain the second 8 bits
+	-- The last 4, which is merged with the TC and BoS
+	lastbits = band(int, 0xf) -- last 4, in the correct position
+	old_last = self.labelend_tc_s
+	old_last = band(old_last, 0x0f) -- retain TC and BoS
+	self.labelend_tc_s = bor(lshift(lastbits, 4), old_last)
+end
+
+--- Retrieve the label.
+--- @return label as 20 bit integer.
+function mplsHeader:getLabel()
+	label = lshift(self.labelstart, 12) + lshift(self.labelmid, 4)
+	label = label + rshift(self.labelend_tc_s, 4)
+	return label
+end
+
+--- Retrieve the label as string.
+--- @return label as string.
+function mplsHeader:getLabelString()
+	return self.getLabel()
+end
+
+
+--- Set the TC
+--- Is the 3 bits after the label in label_tc_s
+--- @param int tc of the mpls header as 3 bit integer.
+function mplsHeader:setTC(int)
+	int = int or 0
+	-- Zero out the previous TC
+	self.labelend_tc_s = band(self.labelend_tc_s, 0xf1)
+	-- Now set it
+	self.labelend_tc_s = bor(self.labelend_tc_s, lshift(int, 1))
+end
+
+--- Retrieve the TC
+--- @return TC as 3 bit integer.
+function mplsHeader:getTC()
+	-- get the 3 bits and shift them to the right
+	return rshift(band(self.labelend_tc_s, 0x0e), 1)
+end
+
+--- Retrieve the TC as string.
+--- @return TC as string.
+function mplsHeader:getTCString()
+	return self.getTC()
+end
+
+
+--- Set the BOS
+--- @param int bos of the mpls header as 1 bit integer.
+function mplsHeader:setBOS(int)
+	int = int or 0
+	-- Zero out the previous BoS
+	self.labelend_tc_s = band(self.labelend_tc_s, 0xfe)
+	-- Now set it
+	self.labelend_tc_s = bor(self.labelend_tc_s, int)
+end
+
+--- Retrieve the BoS.
+--- @return BoS as A bit integer.
+function mplsHeader:getBOS()
+	-- get the bit
+	return  band(self.labelend_tc_s, 0x01)
+end
+
+--- Retrieve the BoS as string.
+--- @return BoS as string.
+function mplsHeader:getBOSString()
+	return self.getBOS()
+end
+
+
+function mplsHeader:setTTL(int)
+	int = int or 255
+	self.ttl = int
+end
+
+--- Retrieve the label.
+--- @return label as A bit integer.
+function mplsHeader:getTTL()
+	return self.ttl 
+end
+
+--- Retrieve the TTL as string.
+--- @return TTL as string.
+function mplsHeader:getTTLString()
+	return self.getTTL()
+end
+
+
+--- Set all members of the mpls header.
+--- Per default, all members are set to default values specified in the respective set function.
+--- Optional named arguments can be used to set a member to a user-provided value.
+--- @param args Table of named arguments. Available arguments: mpls
+--- @param pre prefix for namedArgs. Default 'mpls'.
+--- @code
+--- fill() -- only default values
+--- fill{ mplsLabel=1 } -- all members are set to default values with the exception of mplsLabel, ...
+--- @endcode
+function mplsHeader:fill(args, pre)
+	args = args or {}
+	pre = pre or "mpls"
+
+	self:setLabel(args[pre .. "Label"])
+	self:setTC(args[pre .. "TC"])
+	self:setBOS(args[pre .. "BOS"])
+	self:setTTL(args[pre .. "TTL"])
+end
+
+--- Retrieve the values of all members.
+--- @param pre prefix for namedArgs. Default 'mpls'.
+--- @return Table of named arguments. For a list of arguments see "See also".
+--- @see mplsHeader:fill
+function mplsHeader:get(pre)
+	pre = pre or "mpls"
+
+	local args = {}
+	args[pre .. "Label"] = self:getLabel()
+	args[pre .. "TC"] = self:getTC()
+	args[pre .. "BOS"] = self:getBOS()
+	args[pre .. "TTL"] = self:getTTL()
+
+	return args
+end
+
+--- Retrieve the values of all members.
+--- @return Values in string format.
+function mplsHeader:getString()
+	return "MPLS " .. "Label: " .. self:getLabelString()
+		.. " TC " .. self.getTCString() .. " BoS " .. self.getBOSString()
+		.. " TTL " .. self.getTTLString()
+end
+
+
+------------------------------------------------------------------------
+---- Metatypes
+------------------------------------------------------------------------
+
+mpls.metatype = mplsHeader
+
+
+return mpls

--- a/lua/proto/proto.lua
+++ b/lua/proto/proto.lua
@@ -22,5 +22,6 @@ proto.ipfix = require "proto.ipfix"
 proto.sflow = require "proto.sflow"
 proto.lacp = require "proto.lacp"
 proto.gre = require "proto.gre"
+proto.mpls = require "proto.mpls"
 
 return proto


### PR DESCRIPTION
This PR adds support a single MPLS header for the MPLS layer.

A key point that is lacking is MPLS header stacking, but I'm not sure how that is best implemented in libmoon.

Either in packet.lua a stack can be made of multiple MPLS headers or it can be caught in the mpls.lua layer as a different, at run time defined, header format
This is also of relevance of how the MoonGen flows etc hook into it to define a stack of MPLS headers
