### PR TITLE
Add assertion to file opening

### DIFF
--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -197,7 +197,7 @@ local function newCounter(ctrType, name, dev, format, file, direction)
 			openFiles[fileName].refCount = openFiles[fileName].refCount + 1
 			file = openFiles[fileName].file
 		else
-			file = io.open(file, "w+")
+			file = assert(io.open(file, "w+"))
 			openFiles[fileName] = {refCount = 1, file = file}
 		end
 	end


### PR DESCRIPTION
This avoids storing a nil value as file in the stats counter (if it is not possible to create/open the file).
Later (on stats update) this would cause a "table index is nil" error, which might confuse the developer.