### PR TITLE
Fix use cores from different socket

### DIFF
--- a/lua/libmoon.lua
+++ b/lua/libmoon.lua
@@ -152,7 +152,7 @@ local function getCoreOnSocket(socket)
 		local core = mod.config.cores[i]
 		local status = dpdkc.rte_eal_get_lcore_state(core)
 		if (status == dpdkc.FINISHED or status == dpdkc.WAIT)
-		and (socket == -1 or dpdkc.rte_lcore_to_socket_id_export(core) == socket) then
+		and (socket == nil or dpdkc.rte_lcore_to_socket_id_export(core) == socket) then
 			return core
 		end
 	end


### PR DESCRIPTION
Fixes #110 

As `mod.startTask` seems to be the only function to call `getCoreOnSocket` and it calls it once with no arguments (`socket=nil`), I assume this is how the implementation was intended to be.